### PR TITLE
Use chess game from chess board controller if it exist.

### DIFF
--- a/lib/src/board_model.dart
+++ b/lib/src/board_model.dart
@@ -34,7 +34,7 @@ class BoardModel extends Model {
   bool enableUserMoves;
 
   /// Creates a logical game
-  chess.Chess game = chess.Chess();
+  chess.Chess game;
 
   /// Refreshes board
   void refreshBoard() {
@@ -59,7 +59,12 @@ class BoardModel extends Model {
       this.whiteSideTowardsUser,
       this.chessBoardController,
       this.enableUserMoves) {
-    chessBoardController?.game = game;
+    if (chessBoardController?.game != null) {
+      game = chessBoardController.game;
+    } else {
+      game = chess.Chess();
+      chessBoardController?.game = game;
+    }
     chessBoardController?.refreshBoard = refreshBoard;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chess_board
 description: A Chessboard Widget for Flutter. The widget also maintains game state and gives callbacks for game events.
-version: 0.9.4
+version: 0.9.5
 author: Deven Joshi <deven9852@gmail.com>
 
 homepage: https://www.github.com/deven98/flutter_chess_board


### PR DESCRIPTION
This enables rebuilding of ChessBoard widget (e.g. rotating the board) while state is kept in
controller.

I noticed last pull request merge has not been published to pub.dev, so if you could publish the latest code after this is merged it would be appreciated. Thanks.