### PR TITLE
Fixed undoMove method 

### DIFF
--- a/lib/src/chess_board_controller.dart
+++ b/lib/src/chess_board_controller.dart
@@ -40,9 +40,6 @@ class ChessBoardController extends ValueNotifier<Chess> {
   }
 
   void undoMove() {
-    if (game.half_moves == 0) {
-      return;
-    }
     game.undo_move();
     notifyListeners();
   }


### PR DESCRIPTION
(which worked only when moved pieces without capturing). There was this if statement:

```
    if (game.half_moves == 0) {
      return;
    }
```

which made it impossible to undo a move that was either a capturing move or pawn move (or both), since `half_moves` isn't the number of moves made. It's the number of moves counting towards the 50-move-draw rule. (Also the `game.undo_move();` method is internally already checking if the game history is empty.)

It's a fix to issue #27 